### PR TITLE
Add privacy notice to contact page

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -37,6 +37,12 @@
 
       <button id="submitBtn" type="submit" disabled>Send Enquiry</button>
     </form>
+    <section class="privacy-notice">
+      <h2>Privacy Notice</h2>
+      <p>By submitting this form, you consent to CM Trade Services receiving your enquiry and any contact details you provide (such as your name, email address, or phone number). This information will be used solely to respond to your message and will not be shared with third parties.</p>
+      <p>We use a secure form submission service (FormSubmit) that encrypts your message in transit (HTTPS). However, please avoid sending sensitive personal or financial information through this form.</p>
+      <p>Your message will be delivered to our business email account, which is protected with industry-standard security practices.</p>
+    </section>
     <script>
       const message = document.getElementById('message');
       const contactDetails = document.getElementById('contactDetails');


### PR DESCRIPTION
## Summary
- add privacy notice below contact form to clarify data handling and security

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f6b0cac1083219097886e4485e2f4